### PR TITLE
MK3-113 Add `chk_mounted()` to `ff.h`

### DIFF
--- a/ff.cpp
+++ b/ff.cpp
@@ -2012,7 +2012,7 @@ BYTE check_fs (	/* 0:FAT-VBR, 1:Valid BR but not FAT, 2:Not a BR, 3:Disk error *
 /* Check if the file system object is valid or not                       */
 /*-----------------------------------------------------------------------*/
 
-static
+
 FRESULT chk_mounted (	/* FR_OK(0): successful, !=0: any error occurred */
 	const TCHAR **path,	/* Pointer to pointer to the path name (drive number) */
 	FATFS **rfs,		/* Pointer to pointer to the found file system object */

--- a/ff.h
+++ b/ff.h
@@ -208,6 +208,7 @@ FRESULT open_append (
 );
 
 FRESULT f_mount (BYTE, FATFS*);						/* Mount/Unmount a logical drive */
+FRESULT chk_mounted (const TCHAR **path, FATFS **rfs, BYTE chk_wp);	/* Check if the file system object is valid or not */
 FRESULT f_open (FIL*, const TCHAR*, BYTE);			/* Open or create a file */
 FRESULT f_read (FIL*, void*, UINT, UINT*);			/* Read data from a file */
 FRESULT f_lseek (FIL*, DWORD);						/* Move file pointer of a file object */


### PR DESCRIPTION
Function to check the file system type should be available externally to check the USB format.